### PR TITLE
Feat/histoqc integration

### DIFF
--- a/docs/histoqc.md
+++ b/docs/histoqc.md
@@ -1,0 +1,8 @@
+# Optional HistoQC environment
+
+This env installs HistoQC from our fork (compat fixes for scikit-image 0.22) and pins a known-good stack on Apple Silicon.
+
+## Create and activate
+```bash
+mamba env create -f envs/pyslyde-histoqc.yml
+mamba activate pyslyde-histoqc

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -233,3 +233,37 @@ Now that you have the basics, you can explore:
 * :doc:`examples/index` - More examples and tutorials
 
 For more advanced usage patterns and best practices, see the :doc:`user_guide/index`. 
+
+
+(Optional) Quality Control with HistoQC
+---------------------------------------
+
+If you’d like to quality control your WSIs before or after running PySlyde, 
+we provide a thin wrapper around `HistoQC <https://github.com/fsumayyamohamed/HistoQC>`_.
+
+**Setup (once):**
+
+.. code-block:: bash
+
+   mamba env create -f envs/pyslyde-histoqc.yml
+   mamba activate pyslyde-histoqc
+
+**Run QC:**
+
+.. code-block:: bash
+
+   pyslyde-histoqc -n 4 -o qc_out /path/to/slides/*.ndpi
+
+This produces ``qc_out/results.tsv`` and per-slide artifacts (thumbnails, masks, macros).
+You can use the QC report to exclude slides before running the rest of the PySlyde pipeline.
+
+**Future integration (optional):**
+
+Developers can later add a helper such as:
+
+.. code-block:: python
+
+   from pyslyde import qc
+   slides = qc.find_passed_slides("qc_out")
+
+to automatically load only high-quality slides into the main PySlyde workflow.

--- a/envs/pyslyde-histoqc.yml
+++ b/envs/pyslyde-histoqc.yml
@@ -20,5 +20,5 @@ dependencies:
   - geojson
   - pip:
       - "opencv-python-headless>=4.9,<4.13"
-      # use your fixed HistoQC fork
-      - "histoqc @ git+ssh://git@github.com/fsumayyamohamed/HistoQC@main"
+      # use your fixed HistoQC fork (HTTPS for CI)
+      - "histoqc @ git+https://github.com/fsumayyamohamed/HistoQC@main"

--- a/envs/pyslyde-histoqc.yml
+++ b/envs/pyslyde-histoqc.yml
@@ -1,0 +1,24 @@
+name: pyslyde-histoqc
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - numpy=1.26.*
+  - scipy=1.13.*
+  - scikit-image=0.22.*
+  - scikit-learn=1.4.*
+  - pandas>=2.2,<2.4
+  - matplotlib>=3.7,<3.11
+  - pillow
+  - openslide
+  - openslide-python
+  - tqdm
+  - pyyaml
+  - click
+  - flask
+  - geojson
+  - pip:
+      - "opencv-python-headless>=4.9,<4.13"
+      # use your fixed HistoQC fork
+      - "histoqc @ git+ssh://git@github.com/fsumayyamohamed/HistoQC@main"

--- a/pyslyde/histoqc_wrapper.py
+++ b/pyslyde/histoqc_wrapper.py
@@ -1,0 +1,27 @@
+import sys, argparse
+
+def main():
+    p = argparse.ArgumentParser(description="Run HistoQC on one or more slides (thin wrapper).")
+    p.add_argument("input", nargs="+", help="Slide(s) or glob patterns (e.g. *.svs)")
+    p.add_argument("-o", "--outdir", default=None, help="Output directory (default HistoQC timestamped dir)")
+    p.add_argument("-n", "--nprocs", type=int, default=4, help="Number of processes")
+    args = p.parse_args()
+
+    print(f"[PySlyde-HistoQC] Starting… nprocs={args.nprocs}, outdir={args.outdir or '(default)'}")
+    print(f"[PySlyde-HistoQC] Inputs: {', '.join(args.input)}")
+
+    import histoqc.__main__ as hq  # import after parsing for clearer errors
+
+    # Build argv for HistoQC
+    sys.argv = ["histoqc", "-n", str(args.nprocs)]
+    if args.outdir:
+        sys.argv += ["-o", args.outdir]
+    sys.argv += args.input
+
+    print(f"[PySlyde-HistoQC] Delegating to: {' '.join(sys.argv)}")
+    rc = hq.main()
+    print("[PySlyde-HistoQC] Done ✅" if rc == 0 else f"[PySlyde-HistoQC] Finished with code {rc} ❗ Check error.log.")
+    raise SystemExit(rc)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,12 @@ setup(
             "rocksdb"
         ]
     },
+    entry_points={
+        "console_scripts": [
+            # exposes CLI command
+            "pyslyde-histoqc = pyslyde.histoqc_wrapper:main",
+        ],
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Environment:
envs/pyslyde-histoqc.yml (Python 3.11, scikit-image 0.22, numpy 1.26, pandas 2.3)

Command tested:
pyslyde-histoqc -o qc_out -n 4 test/slide.ndpi

Outcome:

- HistoQC wrapper runs end-to-end successfully
- Generates expected outputs: qc_out/slide.ndpi, results.tsv, and error.log
- No module or binary incompatibility errors
- Compatible with scikit-image 0.22 and numpy 1.26

Key updates in this PR:

- Added new environment file envs/pyslyde-histoqc.yml
- Added docs/histoqc.md
- Added CLI entry-point: pyslyde-histoqc
- Switched HistoQC dependency to HTTPS for CI (git+https://github.com/fsumayyamohamed/HistoQC@main)
- Confirmed PySlyde installs and runs in editable mode